### PR TITLE
Do not specify branch for icons

### DIFF
--- a/io.elementary.Loki.BaseApp.json
+++ b/io.elementary.Loki.BaseApp.json
@@ -81,7 +81,6 @@
             "sources": [{
                 "type": "git",
                 "url": "https://github.com/elementary/icons/",
-                "branch": "master",
                 "commit": "60e5c906d7e16b93dc6758284644e7ee780d4c8d"
             }]
         }


### PR DESCRIPTION
Manifest was not building as branch master was no longer at the specified commit.